### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,9 @@ Basic   | Spec Sheet
 CPU     | Octa-core 2.0 GHz Cortex-A53
 CHIPSET | Qualcomm MSM8953-Pro Snapdragon 626
 GPU     | Adreno 506
-Memory  | 4 GB
+Memory  | 3/4 GB
 Shipped Android Version | Android 7.1.1
-Storage | 64/128 GB
+Storage | 32/64/128 GB
 MicroSD | Up to 256 GB
 Battery | 3100 mAh (non-removable)
 Dimensions | 146.5 x 72.7 x 7.8 mm


### PR DESCRIPTION
The non-Pro bardock device is available in a configuration with 32 GB Storage and 3 GB RAM (which I happen to own).